### PR TITLE
Fix access violation that caused random crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 dwm-win32 is a port of the well known X11 window manager dwm to Microsoft
 Windows.
 
+It is recommended to run dwm-win32 as Administrator so it will catch all windows including those you ran as Administrator.
+
 Description
 ===========
 


### PR DESCRIPTION
- Fixed access violation that caused random crash. For example when logging out in one tag, then logging in, and then logging out from another tag and logging in again, dwm-win32 sometimes crashed and all windows were lost, this was caused because of a null deref.

- Improve error handling, now die macro shows messagebox to let user know of error and win32 last error

- Various other small fixes