### PR TITLE
WinEvent: Now cleaning cloaked windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ tags
 .clangd/
 build/
 compile_commands.json
+
+dwm-win32.log


### PR DESCRIPTION
Problem: Issue #32 - Windows that have gone invisible keep being enumerated (for example the notification window)
Solution: Remove cloaked windows as well (doesn't look like destroy message is sent when the notification window disappears..)