### PR TITLE
fix topbar x position when taskbar is docked on left

### DIFF
--- a/src/dwm-win32.c
+++ b/src/dwm-win32.c
@@ -206,7 +206,7 @@ static HWINEVENTHOOK wineventhook;
 static HFONT font;
 static wchar_t stext[256];
 static int sx, sy, sw, sh; /* X display screen geometry x, y, width, height */ 
-static int by, bh, blw;    /* bar geometry y, height and layout symbol width */
+static int bx, by, bh, blw;    /* bar geometry x, y, height and layout symbol width */
 static int wx, wy, ww, wh; /* window area geometry x, y, width, height, bar excluded */
 static unsigned int seltags, sellt;
 
@@ -1525,7 +1525,7 @@ unmanage(Client *c) {
 
 void
 updatebar(void) {
-    SetWindowPos(barhwnd, showbar ? HWND_TOPMOST : HWND_NOTOPMOST, 0, by, ww, bh, (showbar ? SWP_SHOWWINDOW : SWP_HIDEWINDOW) | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
+    SetWindowPos(barhwnd, showbar ? HWND_TOPMOST : HWND_NOTOPMOST, bx, by, ww, bh, (showbar ? SWP_SHOWWINDOW : SWP_HIDEWINDOW) | SWP_NOACTIVATE | SWP_NOSENDCHANGING);
 }
 
 void
@@ -1548,6 +1548,7 @@ updategeom(void) {
         sh = GetSystemMetrics(SM_CYVIRTUALSCREEN);
     }
 
+    bx = sx;
     bh = 20; /* XXX: fixed value */
 
     /* window area geometry */


### PR DESCRIPTION
This pr fixes the situation that when the system taskbar is docked to the left, then the left side of the topbar will be covered by the taskbar.