### PR TITLE
Make time format uses %ls instead of %s on line 424 & 428

### DIFF
--- a/src/dwm-win32.c
+++ b/src/dwm-win32.c
@@ -424,9 +424,9 @@ drawbar(void) {
             gmtime_s(&date, &timer);
             wcsftime(utctimestr, 255, clockfmt, &date);
 
-            swprintf(timestr, sizeof(timestr), L"%s | UTC: %s", localtimestr, utctimestr);
+            swprintf(timestr, sizeof(timestr), L"%ls | UTC: %ls", localtimestr, utctimestr);
         } else {
-            swprintf(timestr, sizeof(localtimestr), L"%s", localtimestr);
+            swprintf(timestr, sizeof(localtimestr), L"%ls", localtimestr);
         }
 
         dc.w = TEXTW(timestr);


### PR DESCRIPTION
This PR changed on how string format on line `424` and `428` on that line is where the two (or maybe 1) `wchar_t *` are concatenated, but for some reason my build is weirdly not formatted correctly, It may be cause of not using the `build.cmd` to build but I can't manage make my `zig` to compile(it always want WinMain function) probably because i use [msys2 and mingw](https://www.msys2.org/). But as far I can tell it probably good idea to use `%ls` instead of `%s` for portability reason, I know that `swprintf` is automatically treat `%s` as wide character on some compiler but some of the compiler not treating it as wide character. I found stackoverflow article that explain the difference between `%s` and `%ls` as base of my PR, [this stackoverflow question](https://stackoverflow.com/questions/26816547/whats-the-difference-between-printfs-printfls-wprintfs-and-wp), [that stackoverflow question](https://stackoverflow.com/questions/37587777/difference-between-lc-and-c-ls-and-s-in-printf) and [cppreference](https://en.cppreference.com/w/c/io/fprintf). But I still wondering how could you compile the project and the time is formatted perfectly.

My build
![image](https://github.com/prabirshrestha/dwm-win32/assets/68576836/8f217dd7-79dc-40db-b343-24ae12847e37)

The release build from github
![image](https://github.com/prabirshrestha/dwm-win32/assets/68576836/f3f523d4-12dc-4785-8ff6-478f540a4973)

this is my build script that I use to compile the project
```sh
gcc \
    -o dwm-win32.exe src/dwm-win32.c src/win32_utf8.c \
    src/mods/client.c src/mods/display.c src/mods/dwm.c src/mods/eventemitter.c src/mods/hotkey.c \
    -Iextern/lua/src \
    extern/lua/src/lapi.c extern/lua/src/lauxlib.c extern/lua/src/lbaselib.c extern/lua/src/lcode.c extern/lua/src/ldblib.c extern/lua/src/ldebug.c extern/lua/src/ldo.c extern/lua/src/ldump.c extern/lua/src/lfunc.c extern/lua/src/lgc.c extern/lua/src/linit.c extern/lua/src/liolib.c extern/lua/src/llex.c extern/lua/src/lmathlib.c extern/lua/src/lmem.c extern/lua/src/loadlib.c extern/lua/src/lobject.c extern/lua/src/lopcodes.c extern/lua/src/loslib.c extern/lua/src/lparser.c extern/lua/src/lstate.c extern/lua/src/lstring.c extern/lua/src/lstrlib.c extern/lua/src/ltable.c extern/lua/src/ltablib.c extern/lua/src/ltm.c extern/lua/src/lundump.c extern/lua/src/lvm.c extern/lua/src/lzio.c \
    -Iextern/lua-compat-5.3 \
    extern/lua-compat-5.3/compat-5.3.c \
    -municode -w -Wl,-subsystem,windows -lgdi32 -ldwmapi -luser32 -lshell32 \
    -DPROJECT_NAME='"dwm-win32"' -DPROJECT_VER='"0.1.1"' -DPROJECT_VER_MAJOR=0 -DPROJECT_VER_MINOR=1 -DPROJECT_VER_PATCH=1 \
    -DNDEBUG -O2 -s \
    -std=c99 -pedantic -Wall
```