### PR TITLE
Add to the README more required dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ dll because it will be loaded into each process address space.
 COMPILING
 =========
 
-dwm-win32 requires [zig](https://ziglang.org/) to compile. Source code for dwm-win32 is written in C and uses `zig cc` to compile C to native code.
+dwm-win32 requires [zig](https://ziglang.org/) and [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) (You can use the Visual Studio Installer to download only headless build tools without the full IDE) to compile. Source code for dwm-win32 is written in C and uses `zig cc` to compile C to native code.
 You can install the compiler by using [scoop](https://scoop.sh) as `scoop install zig`.
 
 ```cmd

--- a/README.md
+++ b/README.md
@@ -135,8 +135,12 @@ dll because it will be loaded into each process address space.
 COMPILING
 =========
 
-dwm-win32 requires [zig](https://ziglang.org/) and [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) (You can use the Visual Studio Installer to download only headless build tools without the full IDE) to compile. Source code for dwm-win32 is written in C and uses `zig cc` to compile C to native code.
-You can install the compiler by using [scoop](https://scoop.sh) as `scoop install zig`.
+To compile, dwm-win32 requires:
+- [Visual Studio C/C++ Build Tools and Windows SDK](https://visualstudio.microsoft.com/downloads/) (You can use the Visual Studio Installer to download only headless c/c++ build tools and windows sdk without the full IDE)
+- [zig](https://ziglang.org/)
+
+Source code for dwm-win32 is written in C and uses `zig cc` to compile C to native code.
+You can install the Zig compiler by using [scoop](https://scoop.sh) as `scoop install zig`.
 
 ```cmd
 build.cmd


### PR DESCRIPTION
To compile C in this project, zig uses files from Visual Studio Build Tools and Windows SDK

Reason it requires these is because the compile target is msvc and also the project uses the Windows API calls so the Windows SDK is needed anyway.

Zig does come with built in targets for Windows as well, but the MSVC target depends on Visual Studio.