### PR TITLE
Do not manage hanging windows

### DIFF
--- a/src/dwm-win32.c
+++ b/src/dwm-win32.c
@@ -693,6 +693,10 @@ ismanageable(HWND hwnd) {
     if (hwnd == 0)
         return false;
 
+    if (IsHungAppWindow(hwnd)) {
+        return false;
+    }
+
     if (getclient(hwnd))
         return true;
 

--- a/src/dwm-win32.c
+++ b/src/dwm-win32.c
@@ -114,6 +114,7 @@ struct Client {
     bool ignoreborder;
     bool border;
     bool wasvisible;
+    bool ishanging;
     bool isfixed, isurgent; // XXX: useless?
     bool iscloaked; // WinStore apps
     Client *next;
@@ -640,13 +641,19 @@ getclienttitle(HWND hwnd) {
     return buf;
 }
 
-LPWSTR
-getclientprocessname(HWND hwnd) {
+HANDLE
+getclientprocess(HWND hwnd) {
     DWORD processid = 0;
-    DWORD buf_size = MAX_PATH;
-    static wchar_t buf[MAX_PATH];
     GetWindowThreadProcessId(hwnd, &processid);
     HANDLE hProc = OpenProcess(PROCESS_QUERY_INFORMATION, FALSE, processid);
+    return hProc;
+}
+
+LPWSTR
+getclientprocessname(HWND hwnd) {
+    DWORD buf_size = MAX_PATH;
+    static wchar_t buf[MAX_PATH];
+    HANDLE hProc = getclientprocess(hwnd);
     if (hProc) {
         if (QueryFullProcessImageNameW(hProc, 0, buf, &buf_size)) {
             CloseHandle(hProc);
@@ -658,6 +665,18 @@ getclientprocessname(HWND hwnd) {
     return NULL;
 }
 
+BOOL
+isclientdebugged(HWND hwnd) {
+    BOOL debuggerPresent = false;
+    HANDLE hProc = getclientprocess(hwnd);
+    if (!CheckRemoteDebuggerPresent(hProc, &debuggerPresent)) {
+        CloseHandle(hProc);
+        return false;
+    }
+
+    CloseHandle(hProc);
+    return debuggerPresent;
+}
 
 HWND
 getroot(HWND hwnd) {
@@ -694,6 +713,10 @@ ismanageable(HWND hwnd) {
         return false;
 
     if (IsHungAppWindow(hwnd)) {
+        return false;
+    }
+
+    if (isclientdebugged(hwnd)) {
         return false;
     }
 
@@ -1344,6 +1367,19 @@ void
 showhide(Client *c) {
     if (!c)
         return;
+
+    if (isclientdebugged(c->hwnd)) {
+        c->ishanging = true;
+        unmanage(c);
+        return;
+    }
+
+    if (IsHungAppWindow(c->hwnd)) {
+        c->ishanging = true;
+        unmanage(c);
+        return;
+    }
+
     /* XXX: is the order of showing / hidding important? */
     if (!ISVISIBLE(c)) {
         if (IsWindowVisible(c->hwnd)) {
@@ -1517,9 +1553,11 @@ writelog(const Arg *arg) {
 void
 unmanage(Client *c) {
     debug(L" unmanage %s\n", getclienttitle(c->hwnd));
-    if (c->wasvisible)
+
+    // Don't want to touch Window related functions on hanging windows
+    if (c->wasvisible && !c->ishanging)
         setvisibility(c->hwnd, true);
-    if (!c->isfloating)
+    if (!c->isfloating && !c->ishanging)
         setborder(c, true);
     detach(c);
     detachstack(c);


### PR DESCRIPTION
Problem: When dwm-win32 manages non-responding windows it also gets to a non-responding mode

Solution: Avoid managing windows that Windows determines as not responding or windows that are managed by a process that is debugged