### PR TITLE
Fix potential vulnerability in cloned code

### DIFF
--- a/extern/sdl2/src/render/opengles/SDL_render_gles.c
+++ b/extern/sdl2/src/render/opengles/SDL_render_gles.c
@@ -369,6 +369,9 @@ GLES_CreateTexture(SDL_Renderer * renderer, SDL_Texture * texture)
     renderdata->glGenTextures(1, &data->texture);
     result = renderdata->glGetError();
     if (result != GL_NO_ERROR) {
+        if (texture->access == SDL_TEXTUREACCESS_STREAMING) {
+            SDL_free(data->pixels);
+        }
         SDL_free(data);
         return GLES_SetError("glGenTextures()", result);
     }
@@ -397,6 +400,9 @@ GLES_CreateTexture(SDL_Renderer * renderer, SDL_Texture * texture)
 
     result = renderdata->glGetError();
     if (result != GL_NO_ERROR) {
+        if (texture->access == SDL_TEXTUREACCESS_STREAMING) {
+            SDL_free(data->pixels);
+        }
         SDL_free(data);
         return GLES_SetError("glTexImage2D()", result);
     }


### PR DESCRIPTION
This PR fixes a potential security vulnerability in `GLES_CreateTexture` that was cloned from `libsdl-org/SDL` but did not receive the security patch.

**Vulnerability Details:**

* **Affected Function**: `GLES_CreateTexture` in `extern/sdl2/src/render/opengles/SDL_render_gles.c`
* **Original Fix**: https://github.com/libsdl-org/SDL/commit/00b67f55727bc0944c3266e2b875440da132ce4b

**What this PR does:** This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

**References:**

* https://github.com/libsdl-org/SDL/commit/00b67f55727bc0944c3266e2b875440da132ce4b
* [CVE-2022-4743](https://nvd.nist.gov/vuln/detail/cve-2022-4743)

Please review and merge this PR to ensure your repository is protected against this vulnerability.